### PR TITLE
Add link to API extension

### DIFF
--- a/advanced/api-reference.md
+++ b/advanced/api-reference.md
@@ -2,6 +2,7 @@
 title: "API Reference"
 section: advanced
 sortOrder: 350
+callout: This section is incomplete. Please help to improve it.
 ---
 
 An extension has been created to enable an API on TastyIgniter. More details can be found <a href="https://tastyigniter.com/marketplace/item/igniter-api" target="_blank">here</a>.

--- a/advanced/api-reference.md
+++ b/advanced/api-reference.md
@@ -2,5 +2,6 @@
 title: "API Reference"
 section: advanced
 sortOrder: 350
-callout: This section is incomplete. Please help to improve it.
 ---
+
+An extension has been created to enable an API on TastyIgniter. More details can be found here: <a href="https://tastyigniter.com/marketplace/item/igniter-api" target="_blank"></a>

--- a/advanced/api-reference.md
+++ b/advanced/api-reference.md
@@ -4,4 +4,4 @@ section: advanced
 sortOrder: 350
 ---
 
-An extension has been created to enable an API on TastyIgniter. More details can be found here: <a href="https://tastyigniter.com/marketplace/item/igniter-api" target="_blank"></a>
+An extension has been created to enable an API on TastyIgniter. More details can be found <a href="https://tastyigniter.com/marketplace/item/igniter-api" target="_blank">here</a>.


### PR DESCRIPTION
To aid with the visibility of the API extension it could be helpful to link to it in the API section of the documentation. This PR does that.