### PR TITLE
fix image src url to tastyigniter.com

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -32,7 +32,7 @@ There are two ways you can install TastyIgniter, either using the Quick or Comma
    or http://example.com/folder/setup.php
 5. Follow all onscreen instructions and make sure all installation requirements are checked.
 
-<img src="https://tasty-cms.wip/assets/ui/images/mockups/SetupWizard.png" alt="TastyIgniter setup wizard screenshot" style="max-height:250px" />
+<img src="https://tastyigniter.com/assets/ui/images/mockups/SetupWizard.png" alt="TastyIgniter setup wizard screenshot" style="max-height:250px" />
 
 ### Command-line installation
 


### PR DESCRIPTION
an image on the installation page is trying to load from what I'm guessing is a local development server. I replaced the "tasty-cms.wip" domain with "tastyigniter.com" and the image now loads.